### PR TITLE
fix: Sign Transaction

### DIFF
--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -26,7 +26,7 @@ export interface IProviderDisplay {
 
 export interface ISupportedChain {
   methods: {
-    signTransaction?: (hash: string) => Promise<any>
+    signTransaction?: (txData: any) => Promise<any>
     sendTransaction?: (txData: any) => Promise<any>
     getAccounts: () => Promise<any>
     request?: (type: string, data: any) => Promise<any>

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -119,12 +119,12 @@ export const useWalletsOptions = () => {
 export const useSign = () => {
   const context = useContext(WalletsContext)
   const sign = useCallback(
-    async (chainId: IChainType, hash: string) => {
+    async (chainId: IChainType, transactonParams: any) => {
       if (!context) {
         return
       }
 
-      return await context.signMessage(chainId, hash)
+      return await context.signTransaction(chainId, transactonParams)
     },
     [context]
   )

--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -122,25 +122,26 @@ export class WalletsConnector {
     return chains ? chains[chain] : undefined
   }
 
-  public signMessage = async (chainId: IChainType, hash: string) => {
+  public signTransaction = async (
+    chainId: IChainType,
+    transactionParams: Record<string, string | number>
+  ) => {
     if (!window.ethereum) {
       return
     }
 
-    const address = this.getAddress(chainId)
-
     switch (chainId) {
       case IChainType.ethereum: {
         return await window.ethereum.request({
-          method: 'eth_sign',
-          params: [address, hash]
+          method: 'eth_sendTransaction',
+          params: [transactionParams]
         })
       }
 
       default: {
         const targetProvider = this.getChainMethods(chainId)
         if (targetProvider && targetProvider.methods.signTransaction) {
-          return await targetProvider.methods.signTransaction(hash)
+          return await targetProvider.methods.signTransaction(transactionParams)
         }
       }
     }
@@ -202,11 +203,5 @@ export class WalletsConnector {
     )
 
     return await this.loadAccounts()
-  }
-
-  private getAddress = (chainId: IChainType): string => {
-    const accounts = this.getAccounts()
-
-    return accounts[chainId] as string
   }
 }


### PR DESCRIPTION
https://docs.metamask.io/guide/sending-transactions.html#example

Metamask doesnt support signTransaction method also eth_sign just signs a string rather than a transaction.
Metamask specifically says that they dont want to allow eth_sign to sign a transaction to prevent attacks from dApps where they can pretend to be a user.