### PR TITLE
fix: [XDEFI-1496] double trigger accounts event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xdefi/wallets-connector",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Cross chain wallets connector with react hooks",
   "author": "garageinc",
   "license": "MIT",

--- a/src/wallets/index.ts
+++ b/src/wallets/index.ts
@@ -172,8 +172,6 @@ export class WalletsConnector {
       return
     }
 
-    this.setAccounts(providerId, null)
-
     const { connectedList: accounts } =
       await this.connector.loadProviderAccounts(providerId)
 
@@ -205,9 +203,11 @@ export class WalletsConnector {
 
   private setAccounts = (providerId: string, map: IChainWithAccount | null) => {
     if (map) {
-      this.accounts[providerId] = map
+      this.accounts = { ...this.accounts, [providerId]: map }
     } else {
-      delete this.accounts[providerId]
+      const accountsTemp = { ...this.accounts }
+      delete accountsTemp[providerId]
+      this.accounts = accountsTemp
     }
     console.log('setAccounts', providerId, map)
     this.connector.trigger(WALLETS_EVENTS.ACCOUNTS, this.accounts)


### PR DESCRIPTION
## Changes

There is a case when connecting a new wallet, the `WALLETS_EVENTS.ACCOUNTS` event fires twice. The fix prevents `accounts` object mutation.

<!--- Describe your changes -->

## Task tracker card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've checked/updated mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs

<!--- (if appropriate) -->
