### PR TITLE
fix: [XDEFI-5846] add timeout connection when connect to cached

### DIFF
--- a/src/controllers/providers.ts
+++ b/src/controllers/providers.ts
@@ -259,9 +259,21 @@ export class ProviderController {
   }
 
   public async connectToCachedProviders() {
+    const connectionTimeout = 600
     return Promise.allSettled(
       (this.cachedProviders || []).map((pid: string) =>
-        this.connectTo(pid, this.injectedChains[pid])
+        Promise.race([
+          this.connectTo(pid, this.injectedChains[pid]),
+          new Promise((_, reject) =>
+            setTimeout(() => {
+              reject(
+                new Error(
+                  'Connection to cached provider timed out: no response from wallet'
+                )
+              )
+            }, connectionTimeout)
+          )
+        ])
       )
     )
   }


### PR DESCRIPTION
## Changes
Added timeout on connection 600ms. 
I checked connection time, it is about 60-80ms on my apple M1 chip. 
So I guess it is safe to set timeout to 600ms with 500ms margin for various hardware. 
It is also unlikely that time Time To Interact with connect button will take less than timeout time. Mouse travel  to button will take longer. 
<!--- Describe your changes -->

## Task tracker card

<!--- Issue to which the pull request is related -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I've performed a self-review
- [ ] If I make changes to another person's module, I've asked how to use it or request a review
- [ ] I've checked/updated mobile & tablet screens (if have changes in UI)
- [ ] I've added tests (if necessary)

## Screenshots or GIFs

<!--- (if appropriate) -->
