### PR TITLE
feat: add prop which allow update chain selection and reconnect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xdefi/wallets-connector",
-  "version": "2.3.5",
+  "version": "2.4.1",
   "description": "Cross chain wallets connector with react hooks",
   "author": "garageinc",
   "license": "MIT",

--- a/src/components/WalletsModal/WalletsModal.tsx
+++ b/src/components/WalletsModal/WalletsModal.tsx
@@ -42,15 +42,15 @@ export const WalletsModal = ({
 
   const isXdefiWalletConnected = !!multiChains?.injectedChains?.xdefi
   const isCtrlWalletConnected = !!multiChains?.injectedChains?.ctrl
-  const shouldShowChainSelector =
+  const shouldForceReconnectChains =
     forceReconnectChains && (isXdefiWalletConnected || isCtrlWalletConnected)
 
   useEffect(() => {
-    if (shouldShowChainSelector) {
+    if (shouldForceReconnectChains) {
       setIsChainSelectorVisible(true)
       onOpen()
     }
-  }, [shouldShowChainSelector])
+  }, [shouldForceReconnectChains])
 
   const handleShowChainSelector = useCallback(() => {
     setIsChainSelectorVisible(true)
@@ -89,7 +89,7 @@ export const WalletsModal = ({
         renderHeader={
           isChainSelectorVisible
             ? () =>
-                forceReconnectChains ? (
+                shouldForceReconnectChains ? (
                   <CustomHeader>
                     <TitleAlignmentPlaceholder />
                     <Title>Update selected chains</Title>
@@ -109,7 +109,7 @@ export const WalletsModal = ({
           <SelectChainSection
             provider={xdefiLikeProvider}
             onSelect={handleCloseModal}
-            reconnectChains={forceReconnectChains}
+            reconnectChains={shouldForceReconnectChains}
           />
         ) : (
           <SRow>

--- a/src/components/WalletsModal/WalletsModal.tsx
+++ b/src/components/WalletsModal/WalletsModal.tsx
@@ -1,7 +1,13 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react'
 import styled, { DefaultTheme } from 'styled-components'
 
-import { useWalletsOptions } from '../../hooks'
+import { useConnectorMultiChains, useWalletsOptions } from '../../hooks'
 import { useWalletsModal } from '../hooks'
 import { Modal, CloseModalSvg } from '../Modal/Modal'
 import { WalletProvider } from '../Provider'
@@ -15,19 +21,36 @@ interface IProps {
   isDark?: boolean
   themeBuilder?: (isDark: boolean) => DefaultTheme
   className?: string
+  forceReconnectChains?: boolean
 }
 
 export const WalletsModal = ({
   trigger: Trigger,
   themeBuilder,
   isDark = true,
-  className
+  className,
+  forceReconnectChains
 }: IProps) => {
-  const [isChainSelectorVisible, setIsChainSelectorVisible] =
-    useState<boolean>(false)
   const { providers: userOptions } = useWalletsOptions()
   const { isOpen, onClose, onOpen } = useWalletsModal()
   const context = useContext(WalletsContext)
+
+  const multiChains = useConnectorMultiChains()
+
+  const [isChainSelectorVisible, setIsChainSelectorVisible] =
+    useState<boolean>(false)
+
+  const isXdefiWalletConnected = !!multiChains?.injectedChains?.xdefi
+  const isCtrlWalletConnected = !!multiChains?.injectedChains?.ctrl
+  const shouldShowChainSelector =
+    forceReconnectChains && (isXdefiWalletConnected || isCtrlWalletConnected)
+
+  useEffect(() => {
+    if (shouldShowChainSelector) {
+      setIsChainSelectorVisible(true)
+      onOpen()
+    }
+  }, [shouldShowChainSelector])
 
   const handleShowChainSelector = useCallback(() => {
     setIsChainSelectorVisible(true)
@@ -65,13 +88,20 @@ export const WalletsModal = ({
         className={className}
         renderHeader={
           isChainSelectorVisible
-            ? () => (
-                <CustomHeader>
-                  <SBackArrowSvg onClick={handleHideChainSelector} />
-                  <Title>Select chains</Title>
-                  <CloseModalSvg onClick={handleCloseModal} />
-                </CustomHeader>
-              )
+            ? () =>
+                forceReconnectChains ? (
+                  <CustomHeader>
+                    <TitleAlignmentPlaceholder />
+                    <Title>Update selected chains</Title>
+                    <CloseModalSvg onClick={handleCloseModal} />
+                  </CustomHeader>
+                ) : (
+                  <CustomHeader>
+                    <SBackArrowSvg onClick={handleHideChainSelector} />
+                    <Title>Select chains</Title>
+                    <CloseModalSvg onClick={handleCloseModal} />
+                  </CustomHeader>
+                )
             : undefined
         }
       >
@@ -79,6 +109,7 @@ export const WalletsModal = ({
           <SelectChainSection
             provider={xdefiLikeProvider}
             onSelect={handleCloseModal}
+            reconnectChains={forceReconnectChains}
           />
         ) : (
           <SRow>
@@ -138,3 +169,5 @@ const SBackArrowSvg = styled(BackArrowSvg)`
   width: 20px;
   height: 20px;
 `
+
+const TitleAlignmentPlaceholder = styled.div``


### PR DESCRIPTION
 - when `forceReconnectChains` flag set to `true`, it will prompt user to update chains selection in case if user uses XDEFI or CTRL wallet. Option won't work if user connected 3d party wallet. 

example: 
```jsx
        <WalletsModal
          isDark={true}
          trigger={(props: any) => (
            <BtnOpen {...props}>Connect Dark Modal</BtnOpen>
          )}
          forceReconnectChains={true}
        />
```


this will show following popup: 
<img width="985" alt="image" src="https://github.com/user-attachments/assets/2a430784-7f9a-4820-8161-86185b155202">

it will show already connected chains and will allow to select/deselect more chains 
